### PR TITLE
Pull in ses 4.30c against sdk 16.0.0, upgrade nrf utils version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 TAG_PREFIX="repoocaj/ses"
 
-BUILDS=(3.50_sdk_15.0.0 3.50_sdk_15.2.0 4.20_sdk_15.3.0 4.22_sdk_15.3.0 4.22_sdk_16.0.0)
+BUILDS=(3.50_sdk_15.0.0 3.50_sdk_15.2.0 4.20_sdk_15.3.0 4.22_sdk_15.3.0 4.22_sdk_16.0.0 4.30c_sdk_16.0.0)
 
 for build in ${BUILDS[@]}
 do

--- a/config_4.20_sdk_15.3.0/Dockerfile
+++ b/config_4.20_sdk_15.3.0/Dockerfile
@@ -10,10 +10,10 @@ ENV INSTALL="/tmp/install"
 
 RUN mkdir -p ${INSTALL} && \
 	cd ${INSTALL} && \
-	curl https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/nRFCommandLineTools1030Linuxamd64tar.gz -o nrftools.tar.gz && \
+	curl https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/nRFCommandLineTools1050Linuxamd64tar.gz -o nrftools.tar.gz && \
 	tar xf nrftools.tar.gz && \
-	dpkg -i --force-overwrite JLink_Linux_V644e_x86_64.deb && \
-	dpkg -i --force-overwrite nRF-Command-Line-Tools_10_3_0_Linux-amd64.deb && \
+	dpkg -i --force-overwrite JLink_Linux_V654c_x86_64.deb && \
+	dpkg -i --force-overwrite nRF-Command-Line-Tools_10_5_0_Linux-amd64.deb && \
 	cd .. && \
 	rm -rf ${INSTALL}
 

--- a/config_4.22_sdk_15.3.0/Dockerfile
+++ b/config_4.22_sdk_15.3.0/Dockerfile
@@ -10,10 +10,10 @@ ENV INSTALL="/tmp/install"
 
 RUN mkdir -p ${INSTALL} && \
 	cd ${INSTALL} && \
-	curl https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/nRFCommandLineTools1030Linuxamd64tar.gz -o nrftools.tar.gz && \
+	curl https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/nRFCommandLineTools1050Linuxamd64tar.gz -o nrftools.tar.gz && \
 	tar xf nrftools.tar.gz && \
-	dpkg -i --force-overwrite JLink_Linux_V644e_x86_64.deb && \
-	dpkg -i --force-overwrite nRF-Command-Line-Tools_10_3_0_Linux-amd64.deb && \
+	dpkg -i --force-overwrite JLink_Linux_V654c_x86_64.deb && \
+	dpkg -i --force-overwrite nRF-Command-Line-Tools_10_5_0_Linux-amd64.deb && \
 	cd .. && \
 	rm -rf ${INSTALL}
 

--- a/config_4.22_sdk_16.0.0/Dockerfile
+++ b/config_4.22_sdk_16.0.0/Dockerfile
@@ -10,10 +10,10 @@ ENV INSTALL="/tmp/install"
 
 RUN mkdir -p ${INSTALL} && \
 	cd ${INSTALL} && \
-	curl https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/nRFCommandLineTools1030Linuxamd64tar.gz -o nrftools.tar.gz && \
+	curl https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/nRFCommandLineTools1050Linuxamd64tar.gz -o nrftools.tar.gz && \
 	tar xf nrftools.tar.gz && \
-	dpkg -i --force-overwrite JLink_Linux_V644e_x86_64.deb && \
-	dpkg -i --force-overwrite nRF-Command-Line-Tools_10_3_0_Linux-amd64.deb && \
+	dpkg -i --force-overwrite JLink_Linux_V654c_x86_64.deb && \
+	dpkg -i --force-overwrite nRF-Command-Line-Tools_10_5_0_Linux-amd64.deb && \
 	cd .. && \
 	rm -rf ${INSTALL}
 

--- a/config_4.30c_sdk_16.0.0/Dockerfile
+++ b/config_4.30c_sdk_16.0.0/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+	apt-get install -y libx11-6 libfreetype6 libxrender1 libfontconfig1 libxext6 xvfb curl unzip python-pip git zip && \
+	pip install nrfutil
+
+RUN Xvfb :1 -screen 0 1024x768x16 &
+
+ENV INSTALL="/tmp/install"
+
+RUN mkdir -p ${INSTALL} && \
+	cd ${INSTALL} && \
+	curl https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/nRFCommandLineTools1030Linuxamd64tar.gz -o nrftools.tar.gz && \
+	tar xf nrftools.tar.gz && \
+	dpkg -i --force-overwrite JLink_Linux_V644e_x86_64.deb && \
+	dpkg -i --force-overwrite nRF-Command-Line-Tools_10_3_0_Linux-amd64.deb && \
+	cd .. && \
+	rm -rf ${INSTALL}
+
+ENV PATH="/opt/mergehex:/opt/nrfjprog:$PATH"
+
+RUN mkdir -p ${INSTALL} && \
+	cd ${INSTALL} && \
+	curl https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v430c_linux_x64.tar.gz -o ses.tar.gz && \
+	tar xf ses.tar.gz && \
+	echo "yes" | DISPLAY=:1 $(find arm_segger_* -name "install_segger*") --copy-files-to /ses && \
+	cd .. && \
+	rm -rf ${INSTALL}
+
+ENV INSTALL="/nordic"
+
+RUN mkdir -p ${INSTALL} && \
+	cd ${INSTALL} && \
+	curl https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v16.x.x/nRF5_SDK_16.0.0_98a08e2.zip -o nRF5_SDK_16.0.0_98a08e2.zip && \
+	unzip nRF5_SDK_16.0.0_98a08e2.zip && \
+	rm nRF5_SDK_16.0.0_98a08e2.zip && \
+	ln -sf ${INSTALL}/nRF5_SDK_16.0.0_98a08e2 /sdk && \
+	cd ..
+
+ENV INSTALL=
+
+CMD ["/ses/bin/emBuild"]

--- a/config_4.30c_sdk_16.0.0/Dockerfile
+++ b/config_4.30c_sdk_16.0.0/Dockerfile
@@ -10,10 +10,10 @@ ENV INSTALL="/tmp/install"
 
 RUN mkdir -p ${INSTALL} && \
 	cd ${INSTALL} && \
-	curl https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/nRFCommandLineTools1030Linuxamd64tar.gz -o nrftools.tar.gz && \
+	curl https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/nRFCommandLineTools1050Linuxamd64tar.gz -o nrftools.tar.gz && \
 	tar xf nrftools.tar.gz && \
-	dpkg -i --force-overwrite JLink_Linux_V644e_x86_64.deb && \
-	dpkg -i --force-overwrite nRF-Command-Line-Tools_10_3_0_Linux-amd64.deb && \
+	dpkg -i --force-overwrite JLink_Linux_V654c_x86_64.deb && \
+	dpkg -i --force-overwrite nRF-Command-Line-Tools_10_5_0_Linux-amd64.deb && \
 	cd .. && \
 	rm -rf ${INSTALL}
 


### PR DESCRIPTION
Note: Only upgrading nrf utils version from 10.3.0 to 10.5.0 for the 4.xx versions of ses as the path to the nrf utils for the 3.xx ses dockerfile is pointing to an older location of nrf utils and ses 3.xx is older at this point.